### PR TITLE
Implementation of log recovery. (No tests yet)

### DIFF
--- a/src/include/storage/checkpoint_manager.h
+++ b/src/include/storage/checkpoint_manager.h
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include "common/spin_latch.h"
 #include "common/strong_typedef.h"
 #include "storage/checkpoint_io.h"
@@ -50,7 +51,22 @@ class CheckpointManager {
     out_.Open((GetCheckpointFilePath(txn)).c_str());
     // TODO(zhaozhes): persist catalog, get metadata for each table and prepare to checkpoint each table
   }
-
+  
+  /**
+   * Persist a table. This is achieved by first scan the table with a ProjectedColumn buffer, then transfer the data
+   * to a ProjectedRow buffer and write the memory representation of the ProjectedRow directly to disk. Varlen columns
+   * that is not inlined will be written to another checkpoint file.
+   *
+   * TODO(Mengyang): possible optimizations:
+   *                 * store projected columns directly to disk
+   *                 * use a batch of ProjectedRows as buffer
+   *                 * support morsel
+   *
+   * TODO(Mengyang): Currently we require a schema passed in, but this is wrong especially with multi-version schema.
+   *  This is no longer required once the catalog is merged, since we can get the schema of a table from the catalog.
+   */
+  void Checkpoint(const SqlTable &table, const catalog::Schema &schema);
+  
   /**
    * Finish the current checkpoint.
    */
@@ -122,26 +138,14 @@ class CheckpointManager {
       throw std::runtime_error("cannot open checkpoint directory");
     }
   }
-  
-  /**
-   * Persist a table. This is achieved by first scan the table with a ProjectedColumn buffer, then transfer the data
-   * to a ProjectedRow buffer and write the memory representation of the ProjectedRow directly to disk. Varlen columns
-   * that is not inlined will be written to another checkpoint file.
-   *
-   * TODO(Mengyang): possible optimizations:
-   *                 * store projected columns directly to disk
-   *                 * use a batch of ProjectedRows as buffer
-   *                 * support morsel
-   *
-   * TODO(Mengyang): Currently we require a schema passed in, but this is wrong especially with multi-version schema.
-   *  This is no longer required once the catalog is merged, since we can get the schema of a table from the catalog.
-   */
-  void Checkpoint(const SqlTable &table, const catalog::Schema &schema);
 
   /**
    * Begin a recovery. This will clear all registered tables and layouts.
    */
-  void StartRecovery(transaction::TransactionContext *txn) { txn_ = txn; }
+  void StartRecovery(transaction::TransactionContext *txn) {
+    txn_ = txn;
+    tuple_slot_map_.clear();
+  }
 
   /**
    * Register a table in the checkpoint manager, so that its content can be restored during the recovery.
@@ -156,7 +160,17 @@ class CheckpointManager {
   /**
    * Read the content of a file, and reinsert all tuples into the tables already registered.
    */
-  void Recover(const char *log_file_path);
+  void Recover(const char *checkpoint_file_path);
+  
+  
+  /**
+   * Will be called from recover after the tables are recovered from checkpoint files. This function will replay logs
+   * from the timestamp and recover all the logs. The caller should ensure that the tables are already recovered.
+   *
+   * @param log_file_path log file path.
+   * @param checkpoint_timestamp The checkpoint timestamp. All logs with smaller timestamps will be ignored.
+   */
+  void RecoverFromLogs(const char *log_file_path, terrier::transaction::timestamp_t checkpoint_timestamp);
 
   /**
    * Stop the current recovery. All registered tables are cleared.
@@ -173,6 +187,7 @@ class CheckpointManager {
   transaction::TransactionContext *txn_ = nullptr;
   std::vector<SqlTable *> tables_;
   std::vector<BlockLayout *> layouts_;
+  std::unordered_map<TupleSlot, TupleSlot> tuple_slot_map_;
 
   SqlTable *GetTable(catalog::table_oid_t oid) {
     // TODO(mengyang): add support to multiple tables

--- a/src/include/storage/checkpoint_manager.h
+++ b/src/include/storage/checkpoint_manager.h
@@ -165,7 +165,8 @@ class CheckpointManager {
   
   /**
    * Will be called from recover after the tables are recovered from checkpoint files. This function will replay logs
-   * from the timestamp and recover all the logs. The caller should ensure that the tables are already recovered.
+   * from the timestamp and recover all the logs. The caller should ensure that the tables are already recovered,
+   * and the tuple_slot_map_ is built. This function should be called after Recover() or inside Recover().
    *
    * @param log_file_path log file path.
    * @param checkpoint_timestamp The checkpoint timestamp. All logs with smaller timestamps will be ignored.

--- a/src/include/storage/write_ahead_log/log_io.h
+++ b/src/include/storage/write_ahead_log/log_io.h
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <cstring>
 #include <string>
+#include <transaction/transaction_context.h>
 #include "common/macros.h"
 #include "loggers/storage_logger.h"
 
@@ -146,7 +147,11 @@ class BufferedLogReader {
    * @param log_file_path path to the the log file to read from.
    */
   explicit BufferedLogReader(const char *log_file_path) : in_(PosixIoWrappers::Open(log_file_path, O_RDONLY)) {}
-
+  
+  /**
+ * Must call before object is destructed
+ */
+  void Close() { PosixIoWrappers::Close(in_); }
   /**
    * @return if there are contents left in the write ahead log
    */
@@ -190,4 +195,8 @@ class BufferedLogReader {
 
   void RefillBuffer();
 };
+
+// TODO(zhaozhes): copied from log_test.cpp because I believe it should be here because checkpoint recovery need it.
+LogRecord *ReadNextLogRecord(BufferedLogReader *in);
+
 }  // namespace terrier::storage

--- a/src/include/storage/write_ahead_log/log_record.h
+++ b/src/include/storage/write_ahead_log/log_record.h
@@ -168,6 +168,7 @@ class RedoRecord {
   // (varlen? compressed? from an outdated schema?) For now we just assume we can serialize everything out as-is,
   // and the reader still have access to the layout on recovery and can deserialize. This is why we are not
   // just taking an oid.
+  // TODO(zhaozhes): Should be a sql_table instead?
   DataTable *table_;
   TupleSlot tuple_slot_;
   // This needs to be aligned to 8 bytes to ensure the real size of RedoRecord (plus actual ProjectedRow) is also

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -1,5 +1,7 @@
+#include "common/macros.h"
 #include "storage/checkpoint_manager.h"
 #include <vector>
+#include <unordered_map>
 
 #define NUM_RESERVED_COLUMNS 1u
 
@@ -18,15 +20,15 @@ void CheckpointManager::Checkpoint(const SqlTable &table, const catalog::Schema 
 
   for (auto &slot : table) {
     if (table.Select(txn_, slot, row_buffer)) {
-      out_.SerializeTuple(row_buffer, schema, row_pair.second);
+      out_.SerializeTuple(row_buffer, &slot, schema, row_pair.second);
     }
   }
   out_.Persist();
   delete[] buffer;
 }
 
-void CheckpointManager::Recover(const char *log_file_path) {
-  BufferedTupleReader reader(log_file_path);
+void CheckpointManager::Recover(const char *checkpoint_file_path) {
+  BufferedTupleReader reader(checkpoint_file_path);
 
   while (reader.ReadNextBlock()) {
     CheckpointFilePage *page = reader.GetPage();
@@ -37,10 +39,11 @@ void CheckpointManager::Recover(const char *log_file_path) {
 
     ProjectedRow *row = nullptr;
     while ((row = reader.ReadNextRow()) != nullptr) {
+      TupleSlot *slot UNUSED_ATTRIBUTE = reader.ReadNextTupleSlot();
       // loop through columns to deal with non-inlined varlens.
       for (uint16_t projection_list_idx = 0; projection_list_idx < row->NumColumns(); projection_list_idx++) {
         if (!row->IsNull(projection_list_idx)) {
-          storage::col_id_t col = row->ColumnIds()[projection_list_idx];
+          col_id_t col = row->ColumnIds()[projection_list_idx];
           if (layout->IsVarlen(col)) {
             auto *entry = reinterpret_cast<VarlenEntry *>(row->AccessForceNotNull(projection_list_idx));
             if (!entry->IsInlined()) {
@@ -53,8 +56,90 @@ void CheckpointManager::Recover(const char *log_file_path) {
           }
         }
       }
-      table->Insert(txn_, *row);
+      TupleSlot new_slot = table->Insert(txn_, *row);
+      TERRIER_ASSERT(tuple_slot_map_.find(*slot) == tuple_slot_map_.end(),
+                     "Any tuple slot during recovery should be encounted only once.");
+      tuple_slot_map_.insert(*slot, new_slot);
     }
+  }
+}
+
+// TODO(zhaozhes): varlen log is not yet supported in logs.
+void CheckpointManager::RecoverFromLogs(const char *log_file_path, terrier::transaction::timestamp_t checkpoint_timestamp) {
+  // The recovery algorithm scans the log file twice.
+  // On the first pass, a mapping from beginning timestamp (uniquely identifying) to commit timestamp (also uniquely
+  // identifying) is established. The purpose of this pass is to know the commit timestamp of each record,
+  // so that all commits earlier than the checkpoint can be ignored. Moreover, we can tell if a transaction is aborted
+  // if they do not have a commit log record, so it will not appear in the mapping.
+  //
+  // On the second pass, the valid log records will be replayed sequentially from oldest to newest, because the logging
+  // implementation guarantees that the update from the same transaction appears in order, and different transactions
+  // appear in commit order.
+  
+  std::unordered_map<terrier::transaction::timestamp_t, terrier::transaction::timestamp_t> timestamp_map;
+  
+  // First pass
+  BufferedLogReader in(log_file_path);
+  while (in.HasMore()) {
+    LogRecord *log_record = ReadNextLogRecord(&in);
+    if (log_record->RecordType() == LogRecordType::COMMIT) {
+      TERRIER_ASSERT(timestamp_map.find(log_record->TxnBegin()) != timestamp_map.end(),
+                     "Commit records should be mapped to unique begin timestamps.");
+      terrier::transaction::timestamp_t commit_timestamp =
+        log_record->GetUnderlyingRecordBodyAs<CommitRecord>()->CommitTime();
+      // Only need to recover logs commited after the checkpoint
+      if (commit_timestamp > checkpoint_timestamp) {
+        timestamp_map.insert(log_record->TxnBegin(), commit_timestamp);
+      }
+    }
+    delete[] reinterpret_cast<byte *>(log_record);
+  }
+  in.Close();
+  
+  // Second pass
+  in = BufferedLogReader(log_file_path);
+  while (in.HasMore()) {
+    LogRecord *log_record = ReadNextLogRecord(&in);
+    if (timestamp_map.find(log_record->TxnBegin()) == timestamp_map.end()) {
+      // This record is from an uncommited transaction or out-of-date transaction.
+      delete[] reinterpret_cast<byte *>(log_record);
+      continue;
+    }
+    terrier::transaction::timestamp_t commit_timestamp = timestamp_map[log_record->TxnBegin()];
+  
+    // TODO(zhaozhes): support for multi table. However, the log records stores data_table instead of
+    // sql_table, which should be modified I think, so I think we should not currently use the API from log records.
+    // For the above reasons, we currently can only support one table recovery, hard-coded as oid 0.
+    SqlTable *table = GetTable(0);
+    if (log_record->RecordType() == LogRecordType::DELETE) {
+      auto *delete_record = log_record->GetUnderlyingRecordBodyAs<storage::DeleteRecord>();
+      TupleSlot slot = tuple_slot_map_[delete_record->GetTupleSlot()];
+      if (!table->Delete(txn_, slot)) {
+        TERRIER_ASSERT(-1, "Delete failed during log recovery");
+      }
+    } else if (log_record->RecordType() == LogRecordType::REDO) {
+      auto *redo_record = log_record->GetUnderlyingRecordBodyAs<storage::RedoRecord>();
+      TERRIER_ASSERT(tuple_slot_map_.find(redo_record->GetTupleSlot()) != tuple_slot_map_.end(),
+                     "Tuple slot in a log record should have appeared in checkpoints");
+      // Looks like hack here and requires scrutiny once implementation changes.
+      // Under current circumstances, if a tuple slot is not seen before in a checkpointed table,
+      // then we reason it to be an insert record, otherwise an update record.
+      TupleSlot old_slot = redo_record->GetTupleSlot();
+      ProjectedRow *row = redo_record->Delta();
+      if (tuple_slot_map_.find(old_slot) != tuple_slot_map_.end()) {
+        // For an insert record, we have to add its tuple slot into the mapping as well,
+        // to cope with a possible later update on it.
+        TupleSlot slot = table->Insert(txn_, *row);
+        tuple_slot_map_.insert(old_slot, slot);
+      } else {
+        TupleSlot slot = tuple_slot_map_[redo_record->GetTupleSlot()];
+        if (!table->Update(txn_, slot, *row)) {
+          TERRIER_ASSERT(-1, "Update failed during log recovery");
+        }
+      }
+      
+    }
+    delete[] reinterpret_cast<byte *>(log_record);
   }
 }
 

--- a/src/storage/write_ahead_log/log_io.cpp
+++ b/src/storage/write_ahead_log/log_io.cpp
@@ -68,4 +68,32 @@ void BufferedLogReader::RefillBuffer() {
   }
 }
 
+// TODO(zhaozhes): copied from log_test.cpp because I believe it should be here because checkpoint recovery need it.
+LogRecord *ReadNextLogRecord(BufferedLogReader *in) {
+  auto size = in->ReadValue<uint32_t>();
+  byte *buf = common::AllocationUtil::AllocateAligned(size);
+  auto record_type = in->ReadValue<LogRecordType>();
+  auto txn_begin = in->ReadValue<transaction::timestamp_t>();
+  if (record_type == LogRecordType::COMMIT) {
+    auto txn_commit = in->ReadValue<transaction::timestamp_t>();
+    // Okay to fill in null since nobody will invoke the callback.
+    // is_read_only argument is set to false, because we do not write out a commit record for a transaction if it is
+    // not read-only.
+    return CommitRecord::Initialize(buf, txn_begin, txn_commit, nullptr, nullptr, false, nullptr);
+  }
+  // TODO(Tianyu): Without a lookup mechanism this oid is not exactly meaningful. Implement lookup when possible
+  auto table_oid UNUSED_ATTRIBUTE = in->ReadValue<catalog::table_oid_t>();
+  auto tuple_slot = in->ReadValue<TupleSlot>();
+  auto result = RedoRecord::PartialInitialize(buf, size, txn_begin,
+    // TODO(Tianyu): Hacky as hell
+                                              nullptr, tuple_slot);
+  // TODO(Tianyu): For now, without inlined attributes, the delta portion is a straight memory copy. This
+  // will obviously change in the future. Also, this is hacky as hell
+  auto delta_size = in->ReadValue<uint32_t>();
+  byte *dest =
+    reinterpret_cast<byte *>(result->GetUnderlyingRecordBodyAs<RedoRecord>()->Delta()) + sizeof(uint32_t);
+  in->Read(dest, delta_size - static_cast<uint32_t>(sizeof(uint32_t)));
+  return result;
+}
+
 }  // namespace terrier::storage


### PR DESCRIPTION
Logging has no table_oid, making it impossible to recover from multiple tables. Thus the current implementation can only handle a hardcoded table. Next step is to write tests for log recovery.